### PR TITLE
Applicationid and clientkey can be local variables

### DIFF
--- a/src/android/ParsePushNotificationPlugin.java
+++ b/src/android/ParsePushNotificationPlugin.java
@@ -16,8 +16,8 @@ import android.content.Context;
 public class ParsePushNotificationPlugin extends CordovaPlugin {
 	private static final String LOG_TAG = "ParsePush";
 	private CallbackContext callbackContextKeepCallback;
-	private String applicationId;
-	private String clientKey;	
+	//
+	//
 	private static boolean destroyed;
 		
     @Override
@@ -122,16 +122,13 @@ public class ParsePushNotificationPlugin extends CordovaPlugin {
 	}
 	
     private void _setUp(String appId, String clientKey) {
-		this.applicationId = appId;
-		this.clientKey = clientKey;
-
        try {
-           	Parse.initialize(cordova.getActivity(), applicationId, clientKey);
+           	Parse.initialize(cordova.getActivity(), appId, clientKey);
     	   	ParseInstallation.getCurrentInstallation().save();
 
 			SharedPreferences sharedPref = cordova.getActivity().getSharedPreferences("cordova-plugin-pushnotification-parse", Context.MODE_PRIVATE);
 			SharedPreferences.Editor editor = sharedPref.edit();
-			editor.putString("applicationId", applicationId);
+			editor.putString("applicationId", appId);
 			editor.putString("clientKey", clientKey);
 			editor.commit();
 		

--- a/src/android/ParsePushNotificationPlugin.java
+++ b/src/android/ParsePushNotificationPlugin.java
@@ -16,8 +16,6 @@ import android.content.Context;
 public class ParsePushNotificationPlugin extends CordovaPlugin {
 	private static final String LOG_TAG = "ParsePush";
 	private CallbackContext callbackContextKeepCallback;
-	//
-	//
 	private static boolean destroyed;
 		
     @Override
@@ -121,14 +119,14 @@ public class ParsePushNotificationPlugin extends CordovaPlugin {
 		});
 	}
 	
-    private void _setUp(String appId, String clientKey) {
+    private void _setUp(String applicationId, String clientKey) {
        try {
-           	Parse.initialize(cordova.getActivity(), appId, clientKey);
+           	Parse.initialize(cordova.getActivity(), applicationId, clientKey);
     	   	ParseInstallation.getCurrentInstallation().save();
 
 			SharedPreferences sharedPref = cordova.getActivity().getSharedPreferences("cordova-plugin-pushnotification-parse", Context.MODE_PRIVATE);
 			SharedPreferences.Editor editor = sharedPref.edit();
-			editor.putString("applicationId", appId);
+			editor.putString("applicationId", applicationId);
 			editor.putString("clientKey", clientKey);
 			editor.commit();
 		


### PR DESCRIPTION
they're only used in one method.

Signed-off-by: Brenda Wallace <brenda@wallace.net.nz>